### PR TITLE
Bug Fixes

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -34,17 +34,17 @@ class Result implements ResultInterface
 
     public function fetchAllNumeric(): array
     {
-        return $this->fetchAll('fetchNumeric');
+        return $this->connection->fetchAll($this->result,SW_PGSQL_NUM);
     }
 
     public function fetchAllAssociative(): array
     {
-        return $this->fetchAll('fetchAssociative');
+        return $this->connection->fetchAll($this->result,SW_PGSQL_ASSOC);
     }
 
     public function fetchFirstColumn(): array
     {
-        return array_column($this->fetchAll('fetchNumeric'), 0);
+        return array_column($this->fetchAllNumeric(), 0);
     }
 
     public function rowCount(): int
@@ -62,14 +62,5 @@ class Result implements ResultInterface
         $this->result = null;
     }
 
-    private function fetchAll(string $method): array
-    {
-        $result_set = [];
 
-        while ($row = [$this, $method]) {
-            $result_set[] = $row;
-        }
-
-        return $result_set;
-    }
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -29,17 +29,20 @@ class Result implements ResultInterface
 
     public function fetchOne()
     {
-        return $this->connection->fetchRow($this->result)[0];
+        $result = $this->connection->fetchRow($this->result);
+        return $result ? $result[0] : false;
     }
 
     public function fetchAllNumeric(): array
     {
-        return $this->connection->fetchAll($this->result,SW_PGSQL_NUM);
+        $result = $this->connection->fetchAll($this->result,SW_PGSQL_NUM);
+        return $result ? $result : array();
     }
 
     public function fetchAllAssociative(): array
     {
-        return $this->connection->fetchAll($this->result,SW_PGSQL_ASSOC);
+        $result = $this->connection->fetchAll($this->result,SW_PGSQL_ASSOC);
+        return $result ? $result : array();
     }
 
     public function fetchFirstColumn(): array

--- a/src/Result.php
+++ b/src/Result.php
@@ -40,8 +40,7 @@ class Result implements ResultInterface
 
     public function fetchAllAssociative(): array
     {
-        $result = $this->connection->fetchAll($this->result,SW_PGSQL_ASSOC);
-        return $result ? $result : array();
+        return $this->connection->fetchAll($this->result, SW_PGSQL_ASSOC) ?: [];
     }
 
     public function fetchFirstColumn(): array

--- a/src/Result.php
+++ b/src/Result.php
@@ -35,8 +35,7 @@ class Result implements ResultInterface
 
     public function fetchAllNumeric(): array
     {
-        $result = $this->connection->fetchAll($this->result,SW_PGSQL_NUM);
-        return $result ? $result : array();
+        return $this->connection->fetchAll($this->result, SW_PGSQL_NUM) ?: [];
     }
 
     public function fetchAllAssociative(): array


### PR DESCRIPTION
This pull request fixes the following bug : 

1) Current implementation of fetchAllAssociative() and fetchAllNumeric() were causing memory leaks , its been replaced by swoole-postgres's `PostgreSQL->fetchAll(...)` method

2) fetchAllAssociative() , fetchAllNumeric() , fechOne() did not work properly when there was no results , fetchOne() causes 'trying to get index of a boolean' and fetchAllAssociative() , fetchAllNumeric() caused boolean to be returned . which have been fixed to return empty array